### PR TITLE
Improve fullPathRE regex

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -12,6 +12,7 @@ const fetch = require("node-fetch");
 
 let disposables = [];
 let cachedQids = {};
+const fullPathRE = new RegExp(/https?:\/\/www\.wikidata\.org\/(?:wiki|entity)\//)
 
 function activate(context) {
 	setupHoverProvider();
@@ -73,7 +74,6 @@ function disposeAll() {
 
 
 function isQid(word) {
-	let fullPathRE = new RegExp(/https?:\/\/www\.wikidata\.org\/(?:wiki|entity)\/[QP]\d+/);
 	let qidRE = new RegExp(/[QP]\d+/);
 	return fullPathRE.test(word) || qidRE.test(word)
 }
@@ -120,7 +120,7 @@ function createHoverText(obj) {
 
 async function getLabel(qid) {
 	langs = vscode.workspace.getConfiguration('wikidataqidlabels').get('wikidataLanguages', "ru|en")
-	qid = qid.replace('https://www.wikidata.org/wiki/', '')
+	qid = qid.replace(fullPathRE, '')
 	if (qid in cachedQids) {
 		return cachedQids[qid]
 	} else {

--- a/extension.js
+++ b/extension.js
@@ -73,7 +73,7 @@ function disposeAll() {
 
 
 function isQid(word) {
-	let fullPathRE = new RegExp(/https:\/\/www\.wikidata\.org\/wiki\/[QP]\d+/);
+	let fullPathRE = new RegExp(/https?:\/\/www\.wikidata\.org\/(?:wiki|entity)\/[QP]\d+/);
 	let qidRE = new RegExp(/[QP]\d+/);
 	return fullPathRE.test(word) || qidRE.test(word)
 }


### PR DESCRIPTION
So it will also capture this URI format: http://www.wikidata.org/entity/Q1.

I get this format from my SPARQL queries. This URI is also cited here: https://www.wikidata.org/wiki/Wikidata:Glossary#Entity

![image](https://user-images.githubusercontent.com/27153776/99695429-51138380-2a6c-11eb-8e85-a9ef71718214.png)
